### PR TITLE
`register_api_field` is depracated, us `register_rest_field` instead.

### DIFF
--- a/inc/class-builder-post-meta.php
+++ b/inc/class-builder-post-meta.php
@@ -101,7 +101,7 @@ class Builder_Post_Meta extends Builder {
 			)
 		);
 
-		register_api_field(
+		register_rest_field(
 			$this->get_supported_post_types(),
 			$this->args['api_prop'],
 			array(


### PR DESCRIPTION
@joehoyle / @mattheu, any reason the original isn't on the `humanmade` repo? A pain having to fork just to make edits, plus we're out of date with original as Joe's fork is behind.
